### PR TITLE
📚 document getClientSecret expAfter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ const clientSecret = appleSignin.getClientSecret({
   clientID: 'com.company.app', // Apple Client ID
   teamID: 'teamID', // Apple Developer Team ID.
   privateKey: 'PRIVATE_KEY_STRING', // path to private key associated with your client ID. -- Can also be `privateKeyPath` string
-  keyIdentifier: 'XXX' // identifier of the private key.
+  keyIdentifier: 'XXX', // identifier of the private key.
+  // OPTIONAL
+  expAfter: 15777000, // Unix time in seconds after which to expire the clientSecret JWT. Default is now+5 minutes.
 });
 
 const options = {


### PR DESCRIPTION
I spend some time in debugging until I noticed that the clientSecret has an expire time and must be recreated.
So now I added the documentation for the optional expAfter, so people see that this exists.