### PR TITLE
📚 Update description of privateKey to include string and path

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ try {
 const clientSecret = appleSignin.getClientSecret({
   clientID: 'com.company.app', // Apple Client ID
   teamID: 'teamID', // Apple Developer Team ID.
-  privateKeyPath: '/var/www/app/AuthKey_XXXXXXXXXX.p8', // path to private key associated with client ID. -- Can also be `privateKey` string
+  privateKey: 'PRIVATE_KEY_STRING', // private key associated with your client ID. -- Or provide a `privateKeyPath` property instead.
   keyIdentifier: 'XXXXXXXXXX', // identifier of the private key. - can be found here https://developer.apple.com/account/resources/authkeys/list
   // OPTIONAL
   expAfter: 15777000, // Duration after which to expire JWT

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ More detail can be found in [Apple docs](https://developer.apple.com/documentati
 const clientSecret = appleSignin.getClientSecret({
   clientID: 'com.company.app', // Apple Client ID
   teamID: 'teamID', // Apple Developer Team ID.
-  privateKey: 'PRIVATE_KEY_STRING', // path to private key associated with your client ID. -- Can also be `privateKeyPath` string
+  privateKey: 'PRIVATE_KEY_STRING', // private key associated with your client ID. -- Or provide a `privateKeyPath` property instead.
   keyIdentifier: 'XXX', // identifier of the private key.
   // OPTIONAL
   expAfter: 15777000, // Unix time in seconds after which to expire the clientSecret JWT. Default is now+5 minutes.


### PR DESCRIPTION
The old document had said that privateKey was a path.