### PR TITLE
✨ Support for validating Sign in with Apple server-to-server notifications

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -7,6 +7,7 @@ import appleSignin, {
   getAuthorizationToken,
   refreshAuthorizationToken,
   verifyIdToken,
+  verifyWebhookToken,
   _getApplePublicKeys,
 } from '../src/index';
 
@@ -17,6 +18,7 @@ describe('appleSignin test', () => {
     expect(appleSignin.getAuthorizationToken).toBeTruthy();
     expect(appleSignin.refreshAuthorizationToken).toBeTruthy();
     expect(appleSignin.verifyIdToken).toBeTruthy();
+    expect(appleSignin.verifyWebhookToken).toBeTruthy();
     expect(appleSignin._getApplePublicKeys).toBeTruthy();
   });
 
@@ -26,6 +28,7 @@ describe('appleSignin test', () => {
     expect(getAuthorizationToken).toBeTruthy();
     expect(refreshAuthorizationToken).toBeTruthy();
     expect(verifyIdToken).toBeTruthy();
+    expect(verifyWebhookToken).toBeTruthy();
     expect(_getApplePublicKeys).toBeTruthy();
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -27,8 +27,10 @@ export type AppleIdTokenType = {
   nonce_supported: boolean,
   /** The user's email address. */
   email: string,
-  /** A Boolean value that indicates whether the service has verified the email. The value of this claim is always true because the servers only return verified email addresses. */
-  email_verified: boolean,
+  /** A String or Boolean value that indicates whether the service has verified the email. The value of this claim is always true because the servers only return verified email addresses. */
+  email_verified: 'true' | 'false' | boolean,
+  /** A String or Boolean value that indicates whether the email shared by the user is the proxy address. */
+  is_private_email: 'true' | 'false' | boolean,
 };
 
 export type AppleWebhookTokenEventType = {


### PR DESCRIPTION
This PR adds support for validating the JWTs sent in Sign in with Apple server-to-server notifications. It is intended to resolve #78.

---

I've also piggy-backed the following small changes onto this PR:
- Added `is_private_email` to `AppleIdTokenType`
- Updated the type of `AppleIdTokenType.email_verified` to reflect that it may be sent as `"true"` or `"false"`

This is per Apple's documentation here (and also the real data that gets sent): https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/authenticating_users_with_sign_in_with_apple

(That page also says `nonce_supported` is only ever sent as a boolean... gotta love consistency. 🤷)

Please let me know if you'd like me to revert those extra changes, or if you'd prefer them to be a separate issue/PR.