### PR TITLE
Add support to revoke authorization tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,32 @@ try {
 }
 ```
 
+### 5. Revoke tokens
+```js
+
+const clientSecret = appleSignin.getClientSecret({
+  clientID: 'com.company.app', // Apple Client ID
+  teamID: 'teamID', // Apple Developer Team ID.
+  privateKey: 'PRIVATE_KEY_STRING', // private key associated with your client ID. -- Or provide a `privateKeyPath` property instead.
+  keyIdentifier: 'XXXXXXXXXX', // identifier of the private key. - can be found here https://developer.apple.com/account/resources/authkeys/list
+  // OPTIONAL
+  expAfter: 15777000, // Duration after which to expire JWT
+});
+
+const options = {
+  clientID: 'com.company.app', // Apple Client ID
+  clientSecret
+};
+
+try {
+  const {
+    response
+  } = appleSignin.revokeAuthorizationToken(refreshToken, options);
+} catch (err) {
+  console.error(err);
+}
+```
+
 ### Optional: Server-to-Server Notifications
 
 Apple provides realtime server-to-server notifications of several user lifecycle

--- a/src/index.js
+++ b/src/index.js
@@ -253,6 +253,36 @@ const refreshAuthorizationToken = async (
   }).then((res) => res.json());
 };
 
+/** Revoke Apple authorization token */
+const revokeAuthorizationToken = async (
+  refreshToken: string,
+  options: {
+    clientID: string,
+    clientSecret: string,
+  },
+): Promise<AppleAuthorizationTokenResponseType> => {
+  if (!options.clientID) {
+    throw new Error('clientID is empty');
+  }
+  if (!options.clientSecret) {
+    throw new Error('clientSecret is empty');
+  }
+
+  const url = new URL(ENDPOINT_URL);
+  url.pathname = '/auth/revoke';
+
+  const params = new URLSearchParams();
+  params.append('client_id', options.clientID);
+  params.append('client_secret', options.clientSecret);
+  params.append('refresh_token', refreshToken);
+  params.append('token_hint_type', 'refresh_token');
+
+  return fetch(url.toString(), {
+    method: 'POST',
+    body: params,
+  }).then((res) => res.json());
+};
+
 /** Gets an Array of Apple Public Keys that can be used to decode Apple's id tokens */
 const _getApplePublicKeys = async ({
   disableCaching,
@@ -370,6 +400,7 @@ export {
   getClientSecret,
   getAuthorizationToken,
   refreshAuthorizationToken,
+  revokeAuthorizationToken,
   verifyIdToken,
   verifyWebhookToken,
   // Internals - exposed for hacky people
@@ -383,6 +414,7 @@ export default {
   getClientSecret,
   getAuthorizationToken,
   refreshAuthorizationToken,
+  revokeAuthorizationToken,
   verifyIdToken,
   verifyWebhookToken,
   // Internals - exposed for hacky people


### PR DESCRIPTION
### Description:
- Revoke tokens - Invalidate the tokens and associated user authorizations for a user when they are no longer associated with your app.
- More info - https://developer.apple.com/documentation/sign_in_with_apple/revoke_tokens