### PR TITLE
Revoke tokens with access_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ try {
 }
 ```
 
-### 5. Revoke tokens
+### 5. a, Revoke tokens with refresh_token
 ```js
 
 const clientSecret = appleSignin.getClientSecret({
@@ -150,13 +150,37 @@ const clientSecret = appleSignin.getClientSecret({
 
 const options = {
   clientID: 'com.company.app', // Apple Client ID
-  clientSecret
+  clientSecret,
+  tokenHintType: 'refresh_token'
 };
 
 try {
-  const {
-    response
-  } = appleSignin.revokeAuthorizationToken(refreshToken, options);
+  await appleSignin.revokeAuthorizationToken(refreshToken, options);
+} catch (err) {
+  console.error(err);
+}
+```
+
+### 5. b, Revoke tokens with access_token
+```js
+
+const clientSecret = appleSignin.getClientSecret({
+  clientID: 'com.company.app', // Apple Client ID
+  teamID: 'teamID', // Apple Developer Team ID.
+  privateKey: 'PRIVATE_KEY_STRING', // private key associated with your client ID. -- Or provide a `privateKeyPath` property instead.
+  keyIdentifier: 'XXXXXXXXXX', // identifier of the private key. - can be found here https://developer.apple.com/account/resources/authkeys/list
+  // OPTIONAL
+  expAfter: 15777000, // Duration after which to expire JWT
+});
+
+const options = {
+  clientID: 'com.company.app', // Apple Client ID
+  clientSecret,
+  tokenHintType: 'access_token'
+};
+
+try {
+  await appleSignin.revokeAuthorizationToken(accessToken, options);
 } catch (err) {
   console.error(err);
 }

--- a/README.md
+++ b/README.md
@@ -136,6 +136,32 @@ try {
 }
 ```
 
+### 5. Revoke tokens
+```js
+
+const clientSecret = appleSignin.getClientSecret({
+  clientID: 'com.company.app', // Apple Client ID
+  teamID: 'teamID', // Apple Developer Team ID.
+  privateKey: 'PRIVATE_KEY_STRING', // private key associated with your client ID. -- Or provide a `privateKeyPath` property instead.
+  keyIdentifier: 'XXXXXXXXXX', // identifier of the private key. - can be found here https://developer.apple.com/account/resources/authkeys/list
+  // OPTIONAL
+  expAfter: 15777000, // Duration after which to expire JWT
+});
+
+const options = {
+  clientID: 'com.company.app', // Apple Client ID
+  clientSecret
+};
+
+try {
+  const {
+    response
+  } = appleSignin.revokeAuthorizationToken(refreshToken, options);
+} catch (err) {
+  console.error(err);
+}
+```
+
 ### Optional: Server-to-Server Notifications
 
 Apple provides realtime server-to-server notifications of several user lifecycle

--- a/src/index.js
+++ b/src/index.js
@@ -255,12 +255,13 @@ const refreshAuthorizationToken = async (
 
 /** Revoke Apple authorization token */
 const revokeAuthorizationToken = async (
-  refreshToken: string,
+  token: string,
   options: {
     clientID: string,
     clientSecret: string,
+    tokenHintType: 'refresh_token' | 'access_token'
   },
-): Promise<AppleAuthorizationTokenResponseType> => {
+): Promise<any> => {
   if (!options.clientID) {
     throw new Error('clientID is empty');
   }
@@ -274,8 +275,8 @@ const revokeAuthorizationToken = async (
   const params = new URLSearchParams();
   params.append('client_id', options.clientID);
   params.append('client_secret', options.clientSecret);
-  params.append('refresh_token', refreshToken);
-  params.append('token_hint_type', 'refresh_token');
+  params.append('token', token);
+  params.append('token_hint_type', options.tokenHintType);
 
   return fetch(url.toString(), {
     method: 'POST',

--- a/src/index.js
+++ b/src/index.js
@@ -253,6 +253,36 @@ const refreshAuthorizationToken = async (
   }).then((res) => res.json());
 };
 
+/** Revoke Apple authorization token */
+const revokeAuthorizationToken = async (
+  refreshToken: string,
+  options: {
+    clientID: string,
+    clientSecret: string,
+  },
+): Promise<AppleAuthorizationTokenResponseType> => {
+  if (!options.clientID) {
+    throw new Error('clientID is empty');
+  }
+  if (!options.clientSecret) {
+    throw new Error('clientSecret is empty');
+  }
+
+  const url = new URL(ENDPOINT_URL);
+  url.pathname = '/auth/revoke';
+
+  const params = new URLSearchParams();
+  params.append('client_id', options.clientID);
+  params.append('client_secret', options.clientSecret);
+  params.append('refresh_token', refreshToken);
+  params.append('token_hint_type', 'refresh_token');
+
+  return fetch(url.toString(), {
+    method: 'POST',
+    body: params,
+  }).then((res) => res.json());
+};
+
 /** Gets an Array of Apple Public Keys that can be used to decode Apple's id tokens */
 const _getApplePublicKeys = async ({
   disableCaching,
@@ -370,6 +400,7 @@ export {
   getClientSecret,
   getAuthorizationToken,
   refreshAuthorizationToken,
+  revokeAuthorizationToken,
   verifyIdToken,
   verifyWebhookToken,
   // Internals - exposed for hacky people
@@ -383,6 +414,7 @@ export default {
   getClientSecret,
   getAuthorizationToken,
   refreshAuthorizationToken,
+  revokeAuthorizationToken,
   verifyIdToken,
   verifyWebhookToken,
   // Internals - exposed for hacky people


### PR DESCRIPTION
### Description:
- Update revoke to support both refresh and access token.
  - token -> The user refresh token or access token intended to be revoked. The user session associated with the token provided is revoked if the request is successful.
  - token_type_hint -> A hint about the type of the token submitted for revocation. Use refresh_token or access_token.