### PR TITLE
⚡️ add resilience to errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-signin-auth",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "description": " Apple signin for node.",
   "author": {
     "name": "Ahmed Tarek",

--- a/src/index.js
+++ b/src/index.js
@@ -349,6 +349,8 @@ const _getIdTokenApplePublicKey = async (
   header: string,
   cb: (?Error, ?string) => any,
 ): Function => {
+  /** error if found */
+  let error;
   // attempt fetching from cache
   if (APPLE_KEYS_CACHE[header.kid]) {
     return cb(null, APPLE_KEYS_CACHE[header.kid]);
@@ -356,9 +358,10 @@ const _getIdTokenApplePublicKey = async (
   try {
     // fetch and cache current Apple public keys
     await _getApplePublicKeys();
-  } catch (error) {
+  } catch (err) {
     // key was not fetched - highly unlikely, means apple is having issues or somebody faked the JSON
-    return cb(error); 
+    // we will still try to get the key from the cache
+    error = err;
   }
   // attempt fetching from cache
   if (APPLE_KEYS_CACHE[header.kid]) {

--- a/src/index.js
+++ b/src/index.js
@@ -353,8 +353,13 @@ const _getIdTokenApplePublicKey = async (
   if (APPLE_KEYS_CACHE[header.kid]) {
     return cb(null, APPLE_KEYS_CACHE[header.kid]);
   }
-  // fetch and cache current Apple public keys
-  await _getApplePublicKeys();
+  try {
+    // fetch and cache current Apple public keys
+    await _getApplePublicKeys();
+  } catch (error) {
+    // key was not fetched - highly unlikely, means apple is having issues or somebody faked the JSON
+    return cb(error); 
+  }
   // attempt fetching from cache
   if (APPLE_KEYS_CACHE[header.kid]) {
     return cb(null, APPLE_KEYS_CACHE[header.kid]);

--- a/src/index.js
+++ b/src/index.js
@@ -368,7 +368,7 @@ const _getIdTokenApplePublicKey = async (
     return cb(null, APPLE_KEYS_CACHE[header.kid]);
   }
   // key was not fetched - highly unlikely, means apple is having issues or somebody faked the JSON
-  return cb(new Error('input error: Invalid id token public key id'));
+  return cb(error || new Error('input error: Invalid id token public key id'));
 };
 
 /** Verifies an Apple id token */


### PR DESCRIPTION
### Description:
- ⚡️ add resilience to errors

closes https://github.com/a-tokyo/apple-signin-auth/issues/182